### PR TITLE
ecspresso v0.17.2

### DIFF
--- a/ecspresso.rb
+++ b/ecspresso.rb
@@ -1,8 +1,8 @@
 class Ecspresso < Formula
-  version '0.17.0'
+  version '0.17.2'
   homepage 'https://github.com/kayac/ecspresso'
-  url "https://github.com/kayac/ecspresso/releases/download/v0.17.0/ecspresso-v0.17.0-darwin-amd64"
-  sha256 '5928d31a3616b6137e81d57c537fc3ffac6aa5da540b1cb5d17a88b4c04d9972'
+  url "https://github.com/kayac/ecspresso/releases/download/v0.17.2/ecspresso-v0.17.2-darwin-amd64"
+  sha256 '348a69aa1a12117de6e85ff2e025fcc80567c451db9481134871914ae46d0edd'
   head 'https://github.com/kayac/ecspresso.git'
 
   head do
@@ -13,7 +13,7 @@ class Ecspresso < Formula
     if build.head?
       system 'make', 'build'
     end
-    system 'mv', 'ecspresso-v0.17.0-darwin-amd64', 'ecspresso'
+    system 'mv', 'ecspresso-v0.17.2-darwin-amd64', 'ecspresso'
     bin.install 'ecspresso'
   end
 end


### PR DESCRIPTION
update ecspresso
https://github.com/kayac/ecspresso/releases/tag/v0.17.2

```console
$ brew upgrade ./ecspresso.rb
Updating Homebrew...
==> Upgrading 1 outdated package:
ecspresso 0.17.0 -> 0.17.2
==> Upgrading ecspresso 0.17.0 -> 0.17.2
==> Downloading https://github.com/kayac/ecspresso/releases/download/v0.17.2/ecspresso-v0.17.2-darwin-amd64
Already downloaded: /Users/nagata-hiroaki/Library/Caches/Homebrew/downloads/61f26c75c2056329d96e97c7db55e754fed4172ce05fc817a885e0336c875efa--ecspresso-v0.17.2-darwin-amd64
==> mv ecspresso-v0.17.2-darwin-amd64 ecspresso
🍺  /usr/local/Cellar/ecspresso/0.17.2: 3 files, 23.0MB, built in 4 seconds
Removing: /usr/local/Cellar/ecspresso/0.17.0... (3 files, 23.0MB)

$ ecspresso version
ecspresso v0.17.2
```