### PR TITLE
tap ecspresso@0.99

### DIFF
--- a/.github/workflows/diff-test.yml
+++ b/.github/workflows/diff-test.yml
@@ -22,4 +22,4 @@ jobs:
         run: |
           git fetch origin master
           git diff origin/master --name-only | fgrep .rb | grep -v @ \
-          | xargs -n 1 brew install --build-from-source
+          | xargs -n 1 -r brew install --build-from-source

--- a/.github/workflows/diff-test.yml
+++ b/.github/workflows/diff-test.yml
@@ -19,7 +19,8 @@ jobs:
       - name: test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          XARGS_OPT: ${{ (runner.os == 'Linux' && '-r') || (runner.os == 'macOS' && '') }}
         run: |
           git fetch origin master
           git diff origin/master --name-only | fgrep .rb | grep -v @ \
-          | xargs -n 1 -r brew install --build-from-source
+          | xargs -n 1 $XARGS_OPT brew install --build-from-source

--- a/.github/workflows/diff-test.yml
+++ b/.github/workflows/diff-test.yml
@@ -21,5 +21,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git fetch origin master
-          git diff origin/master --name-only | fgrep .rb \
+          git diff origin/master --name-only | fgrep .rb | grep -v @ \
           | xargs -n 1 brew install --build-from-source

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,4 +20,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ls *.rb | xargs -n 1 brew install --build-from-source
+          ls *.rb | grep -v @ | xargs -n 1 brew install --build-from-source

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ update/%:
 	maltmill -w $*.rb
 
 update-all:
-	grep -l darwin *.rb | xargs -n 1 maltmill -w
+	grep -l darwin *.rb | grep -v @ | xargs -n 1 maltmill -w
 
 test/%:
 	brew install --build-from-source $*

--- a/ecspresso@0.99.rb
+++ b/ecspresso@0.99.rb
@@ -1,0 +1,25 @@
+class EcspressoAT099 < Formula
+    version '0.99.5'
+    homepage 'https://github.com/kayac/ecspresso'
+    if OS.mac?
+      url "https://github.com/kayac/ecspresso/releases/download/v0.99.5/ecspresso-v0.99.5-darwin-amd64.zip"
+      sha256 '0fe005d1d47f31ae8a6cfb311ec14032298ec7894d2a821a8e5a9cef618303a7'
+    end
+    if OS.linux?
+      url "https://github.com/kayac/ecspresso/releases/download/v0.99.5/ecspresso-v0.99.5-linux-amd64.zip"
+      sha256 '1aee66a650d739297b020c4da39cd3a37cfa491936b104be0a5454d69909a2cc'
+    end
+    head 'https://github.com/kayac/ecspresso.git'
+
+    head do
+      depends_on 'go' => :build
+    end
+
+    def install
+      if build.head?
+        system 'make', 'build'
+      end
+      system 'mv ecspresso-v*-*-amd64 ecspresso'
+      bin.install 'ecspresso'
+    end
+  end

--- a/ecspresso@0.99.rb
+++ b/ecspresso@0.99.rb
@@ -1,5 +1,6 @@
 class EcspressoAT099 < Formula
     version '0.99.5'
+    desc "This is a pre-release version of ecspresso. Fomula for a limited time"
     homepage 'https://github.com/kayac/ecspresso'
     if OS.mac?
       url "https://github.com/kayac/ecspresso/releases/download/v0.99.5/ecspresso-v0.99.5-darwin-amd64.zip"


### PR DESCRIPTION
I want to install v0.99. * Ecspresso via homebrew.

```
brew install kayac/tap/ecspresso@0.99
```
Such an explicit installation will install 0.99. Other than that, I think 0.18 is the priority

### if aleady install `kayac/tap/ecspresso`
If you already have kayac/tap/ecspresso installed, you should get an error like this:
```
Updating Homebrew...
==> Downloading https://github.com/kayac/ecspresso/releases/download/v0.99.5/ecspresso-v0.99.5-darwin-amd64.zip
Already downloaded: /Users/****/Library/Caches/Homebrew/downloads/e823ece75bff5e0877fa392f88e64d0fd5896130e3714af1632154182551a45c--ecspresso-v0.99.5-darwin-amd64.zip
==> mv ecspresso-v*-*-amd64 ecspresso
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/ecspresso
Target /usr/local/bin/ecspresso
is a symlink belonging to ecspresso. You can unlink it:
  brew unlink ecspresso

To force the link and overwrite all conflicting files:
  brew link --overwrite ecspresso@0.99

To list all files that would be deleted:
  brew link --overwrite --dry-run ecspresso@0.99

Possible conflicting files are:
/usr/local/bin/ecspresso -> /usr/local/Cellar/ecspresso/0.18.0/bin/ecspresso
==> Summary
🍺  /usr/local/Cellar/ecspresso@0.99/0.99.5: 3 files, 23.3MB, built in 3 seconds
```

In this case, please do as follows:
```
brew unlink ecspresso
brew link ecspresso@0.99
```

### If you want to return to the original 0.18
```
brew unlink ecspresso@0.99
brew link ecspresso
```

### When version 1 is released
```
brew uninstall ecspresso@0.99
brew upgrade ecspresso
```

goodbye expresso@0.99
and revert this PR