### PR TITLE
Fix head ecspresso installation

### DIFF
--- a/ecspresso.rb
+++ b/ecspresso.rb
@@ -17,7 +17,8 @@ class Ecspresso < Formula
 
   def install
     if build.head?
-      system 'make', 'build'
+      system 'make', 'cmd/ecspresso/ecspresso'
+      system 'mv', 'cmd/ecspresso/ecspresso', '.'
     end
     bin.install 'ecspresso'
   end


### PR DESCRIPTION
Currently, when installing head ecspresso with hombrew, the following error occurs.

```
% brew install ecspresso --head

Last 15 lines from /Users/genki.sugawara/Library/Logs/Homebrew/ecspresso/01.make:
2021-10-27 08:32:20 +0000

make
build

make: *** No rule to make target `build'.  Stop.

If reporting this issue please do so at (not Homebrew/brew or Homebrew/core):
  https://github.com/kayac/homebrew-tap/issues

Please create pull requests instead of asking for help on Homebrew's GitHub,
Twitter or any other official channels.
```

So modify the make target.
