### PR TITLE
fix broken workflows

### DIFF
--- a/.github/workflows/diff-test.yml
+++ b/.github/workflows/diff-test.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: setup brew path
         run: echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/diff-test.yml
+++ b/.github/workflows/diff-test.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: setup brew path
         run: echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: setup brew path
         run: echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: setup brew path
         run: echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -11,8 +11,8 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
-      - uses: aquaproj/aqua-installer@v3.0.0
+        uses: actions/checkout@v5
+      - uses: aquaproj/aqua-installer@v4.0.2
         with:
           aqua_version: v2.3.1
       - name: update & pr

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -11,8 +11,8 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
-      - uses: aquaproj/aqua-installer@v4.0.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: aquaproj/aqua-installer@d1fe50798dbadd4eb5b98957290ca175f6b4870f # v4.0.2
         with:
           aqua_version: v2.3.1
       - name: update & pr
@@ -28,6 +28,6 @@ jobs:
           git config --global user.name ossbot
           git commit -m 'update to newer version'
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:
           title: update to newer version


### PR DESCRIPTION
This pull request updates several GitHub Actions used in workflow files to pin them to specific commit SHAs and newer versions. The main goal is to improve security and reliability by referencing exact versions for actions and dependencies.

**Workflow action updates:**

* Updated `actions/checkout` to use commit SHA `08c6903cd8c0fde910a37f88322edcfb5dd907a8` (v5.0.0) in `.github/workflows/diff-test.yml`, `.github/workflows/test.yml`, and `.github/workflows/update.yml`. [[1]](diffhunk://#diff-dce09b5aaf785f1d294d267b347e8b0b3f71b8a50c9fd0f7e0ade9037a5ffcefL17-R17) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L19-R19) [[3]](diffhunk://#diff-571e661e1640e6f1f415c087c9a72af346ea9fd4655ff5545e5ad6ea596bab97L14-R15)
* Updated `aquaproj/aqua-installer` to use commit SHA `d1fe50798dbadd4eb5b98957290ca175f6b4870f` (v4.0.2) in `.github/workflows/update.yml`.
* Updated `peter-evans/create-pull-request` to use commit SHA `c5a7806660adbe173f04e3e038b0ccdcd758773c` (v6.1.0) in `.github/workflows/update.yml`.